### PR TITLE
Fix crash if block is nil

### DIFF
--- a/JMGBlockSegue/UIViewController+BlockSegue.m
+++ b/JMGBlockSegue/UIViewController+BlockSegue.m
@@ -71,14 +71,14 @@ void BlockSegue(void) {
 
 #pragma mark - Public interface
 -(void)configureSegue:(NSString *)identifier withBlock:(UIViewControllerSegueBlock)block {
-    NSMutableDictionary *dBlocks = self.jmg_dictionaryBlock ?: [self jmg_createDictionaryBlock];
-    [dBlocks setObject:block forKey:identifier];
+    if (block) {
+        NSMutableDictionary *dBlocks = self.jmg_dictionaryBlock ?: [self jmg_createDictionaryBlock];
+        [dBlocks setObject:block forKey:identifier];
+    }
 }
 
 -(void)performSegueWithIdentifier:(NSString *)identifier sender:(id)sender withBlock:(UIViewControllerSegueBlock)block {
-    if (block) {
-        [self configureSegue:identifier withBlock:block];
-    }
+    [self configureSegue:identifier withBlock:block];
     [self performSegueWithIdentifier:identifier sender:sender];
 }
 


### PR DESCRIPTION
Sending `nil` for block results in crash. 
example: `[self performSegueWithIdentifier:@"Identifier" sender:nil withBlock:nil];`

Check that block != nil before configuring segue. 
