### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Cocoa Pods Version](https://cocoapod-badges.herokuapp.com/v/UIViewController+BlockSegue/badge.png)
-![Cocoa Pods Platform](https://cocoapod-badges.herokuapp.com/p/UIViewController+BlockSegue/badge.png)
+![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/UIViewController+BlockSegue/badge.png)
+![CocoaPods Platform](https://cocoapod-badges.herokuapp.com/p/UIViewController+BlockSegue/badge.png)
 [![Build Status](https://travis-ci.org/patoroco/UIViewController-BlockSegue.svg)](https://travis-ci.org/patoroco/UIViewController-BlockSegue)
 
 Are you tired of writing an ugly and big `-prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender:` method like that?


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
